### PR TITLE
Tag-ification of recipe

### DIFF
--- a/src/main/resources/data/assemblylinemachines/recipes/crafting/titanium_blade_piece.json
+++ b/src/main/resources/data/assemblylinemachines/recipes/crafting/titanium_blade_piece.json
@@ -6,10 +6,10 @@
 	],
 	"key":{
 		"x":{
-			"item": "assemblylinemachines:titanium_ingot"
+			"tag": "forge:ingots/titanium"
 		},
 		"y":{
-			"item": "assemblylinemachines:titanium_nugget"
+			"tag": "forge:nuggets/titanium"
 		}
 	},
 	"result":{


### PR DESCRIPTION
Because everything breaks if titanium ore is generated by other mod.